### PR TITLE
Update docs example for insert_by_period idempotent loads

### DIFF
--- a/docs/materialisations.md
+++ b/docs/materialisations.md
@@ -224,7 +224,7 @@ Example incremental logic containing a `LEFT OUTER JOIN` (taken from dbtvault's 
 === "hub Macro LEFT OUTER JOIN"
 
     ```jinja
-    {%- if is_incremental() %}
+    {%- if dbtvault.is_any_incremental() %}
     LEFT JOIN {{ this }} AS d
     ON a.CUSTOMER_HK = d.CUSTOMER_HK
     WHERE d.CUSTOMER_HK IS NULL


### PR DESCRIPTION
I am using the `vault_insert_by_period` materialization _outside_ of the dbtvault framework after being pointed to it by https://github.com/dbt-labs/dbt-labs-experimental-features/issues/32#issuecomment-1251795528.

The dbtvault docs tripped me up for a while before I realized the `is_incremental()` condition in the example (see changes) will never be met when `materialized = 'vault_insert_by_period'`. Instead I used `dbtvault.is_any_incremental()` which worked like a charm.

This updates the docs to reflect that so that others don't get caught out by it.