### PR TITLE
Update index.md: To fix broken links for the blog posts mentioned in …

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,8 +76,8 @@ information:
 
 ### Blogs and Downloads
 
-- [What is Data Vault?](https://www.data-vault.co.uk/what-is-data-vault/)
-- [Agile Modeling: Not an Option Anymore](https://www.vertabelo.com/blog/data-vault-series-agile-modeling-not-an-option-anymore/)
+- [What is Data Vault?](https://data-vault.com/what-is-data-vault/)
+- [Data Valut Modelling Basics](https://vertabelo.com/blog/data-vault-series-data-vault-2-0-modeling-basics/)
 
 ## Roadmap and Changelog
 


### PR DESCRIPTION
…the bottom of the main page

One link has been updated to pint to the new link for the same blog post https://data-vault.com/what-is-data-vault/ from https://www.data-vault.co.uk/what-is-data-vault/

Another link has been replaced as the page has been removed: https://vertabelo.com/blog/data-vault-series-data-vault-2-0-modeling-basics/ FROM
https://www.vertabelo.com/blog/data-vault-series-agile-modeling-not-an-option-anymore/